### PR TITLE
added support for custom upload url

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,37 @@ upload({
 });
 ```
 
+## Custom upload URL
+If you are using Bugsnag Enterprise (on premise installation) with a custom domain, you can pass an optional third argument on the upload method to define your upload url.
+
+Same example as above with custom upload url:
+
+
+```js
+import path from 'path';
+import { upload } from 'bugsnag-sourcemaps';
+
+upload({
+  apiKey: 'YOUR_API_KEY_HERE',
+  appVersion: '1.2.3', // optional
+  minifiedUrl: 'http://example.com/assets/example.min.js', // supports wildcards
+  sourceMap: path.resolve(__dirname, 'path/to/example.js.map'),
+  minifiedFile: path.resolve(__dirname, 'path/to/example.min.js'), // optional
+  overwrite: true, // optional
+  sources: {
+    'http://example.com/assets/main.js': path.resolve(__dirname, 'path/to/main.js'),
+    'http://example.com/assets/utils.js': path.resolve(__dirname, 'path/to/utils.js'),
+  },
+}, function(err) {
+  if (err) {
+    throw new Error('Something went wrong! ' + err.message);
+  }
+  console.log('Sourcemap was uploaded successfully.');
+},
+   'https://bugsnag.my-company.com'  // optional
+);
+```
+
 ## License
 
 MIT License ❤️

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const DEFAULT_OPTIONS = {
   // sources: {},
 };
 
-function upload(options, callback) {
+function upload(options, callback, customUploadUrl) {
   const promise = new Promise(function (resolve, reject) {
     const optionsWithDefaults = Object.assign({}, DEFAULT_OPTIONS, options);
     if (!optionsWithDefaults.apiKey) {
@@ -44,7 +44,7 @@ function upload(options, callback) {
       }
     });
     request.post({
-      url: UPLOAD_URL,
+      url: customUploadUrl || UPLOAD_URL,
       formData,
     }, function (err, res, body) {
       if (err || res.statusCode !== 200) {


### PR DESCRIPTION
Hi, I've found your module very useful but since I'm working with Bugsnag Enterprise version, which is installed on-premise on internal servers in my company, I need it to have custom upload urls support. 

Since it was a small effort I have done it by myself and as you can see it's just few changes and keeps the code backward compatible.

Hope you will appreciate, thanks for sharing this!