### PR TITLE
Add wildcard prefix to minified url when using flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,10 @@ function transformOptions(options) {
   if (options.codeBundleId && options.appVersion) {
     delete options.appVersion;
   }
+  if (options.addWildcardPrefix && options.minifiedUrl) {
+    if (options.minifiedUrl.indexOf('://') == -1 && options.minifiedUrl[0] != '*')
+      options.minifiedUrl = '*/' + options.minifiedUrl;
+  }
   if (options.stripProjectRoot) {
     options.tempDir = fs.mkdtempSync('bugsnag-sourcemaps');
     return transformSourcesMap(options);


### PR DESCRIPTION
When using `--add-wildcard-prefix`, also add the prefix to the `--minified-url` argument if specified, unless its a fully specified URL or already prefixed.

Fixes #5.