### PR TITLE
Replace fs with graceful-fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const request = require('request');
 const path = require('path');
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/jmshal/bugsnag-sourcemaps.git"
   },
   "dependencies": {
+    "graceful-fs": "^4.1.11",
     "listr": "^0.12.0",
     "meow": "^3.7.0",
     "rc": "^1.2.1",


### PR DESCRIPTION
This fixes #7. [`Graceful-fs`](https://github.com/isaacs/node-graceful-fs) is a drop-in replacement for fs, which automatically backs-off when hitting EMFILE-errors.

As a side-note: Shouldn't `node_modules` be included in `.gitignore`? In this PR I didn't commit changes in `node_modules` as I assume leaving it out of `.gitignore` was a mistake.