### PR TITLE
stripProjectRoot by default

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,7 +21,6 @@ const cli = meow(`
       -p, --minified-file PATH   The path of the bundle (local)
       -u, --upload-sources       Upload source files referenced by the source map
       -r, --project-root PATH    The root path to remove from absolute file paths
-      -t, --strip-project-root   Strip the root path from file paths in the source map
       -w, --add-wildcard-prefix  Insert a wildcard prefix when stripping root path
       -o, --overwrite            Overwite previously uploaded source maps
 
@@ -51,7 +50,6 @@ const cli = meow(`
     p: 'minified-file',
     r: 'project-root',
     s: 'source-map',
-    t: 'strip-project-root',
     u: 'upload-sources',
     v: 'app-version',
     w: 'add-wildcard-prefix',

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,59 @@
 const {
+  stripProjectRoot,
   upload,
 } = require('./index');
 
 test('upload function exists', () => {
   expect(typeof upload).toBe('function');
+});
+
+describe('stripProjectRoot', () => {
+  test('strips project root', () => {
+    expect(stripProjectRoot(
+      '/Users/test/git/my-app/',
+      '/Users/test/git/my-app/src/index.js'
+    )).toBe('src/index.js');
+  });
+
+  test('strips project root with no trailing slash', () => {
+    expect(stripProjectRoot(
+      '/Users/test/git/my-app',
+      '/Users/test/git/my-app/src/index.js'
+    )).toBe('src/index.js');
+  });
+
+  test(`wont strip project root when path is not within project root`, () => {
+    expect(stripProjectRoot(
+      '/Users/test/git/another-app',
+      '/Users/test/git/my-app/src/index.js'
+    )).toBe('/Users/test/git/my-app/src/index.js');
+  });
+
+  test('strips project root from node_moodules', () => {
+    expect(stripProjectRoot(
+      '/Users/test/git/my-app',
+      '/Users/test/git/my-app/node_modules/some-module/lib/something.js'
+    )).toBe('node_modules/some-module/lib/something.js');
+  });
+
+  test(`won't strip project root when path is absolute`, () => {
+    expect(stripProjectRoot(
+      '/Users/test/git/my-app',
+      'src/index.js'
+    )).toBe('src/index.js');
+  });
+
+  test('strips project root for Windows paths (forward slash)', () => {
+    expect(stripProjectRoot(
+      'C:/Users/test/git/my-app',
+      'C:/Users/test/git/my-app/src/index.js'
+    )).toBe('src\\index.js');
+  });
+
+  test('strips project root for Windows paths (back slash)', () => {
+    expect(stripProjectRoot(
+      'C:\\Users\\test\\git\\my-app',
+      'C:\\Users\\test\\git\\my-app\\src\\index.js'
+    )).toBe('src\\index.js');
+  });
 });


### PR DESCRIPTION
The `stripProjectRoot` option is now enabled by default.  I also wrote some tests (using Jest), which uncovered the fact that running the CLI on macOS/Linux for a sourcemap file generated on Windows would fail to produce stripped paths - that has been fixed.