### PR TITLE
Put uploading sources in node_modules behind a flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,7 @@ const cli = meow(`
       -s, --source-map PATH      The path of the source map file (local)
       -p, --minified-file PATH   The path of the bundle (local)
       -u, --upload-sources       Upload source files referenced by the source map
+      -n, --upload-node-modules  Upload dependency files referenced by the source map
       -r, --project-root PATH    The root path to remove from absolute file paths
       -w, --add-wildcard-prefix  Insert a wildcard prefix when stripping root path
       -o, --overwrite            Overwite previously uploaded source maps
@@ -46,6 +47,7 @@ const cli = meow(`
     h: 'help',
     k: 'api-key',
     m: 'minified-url',
+    n: 'upload-node-modules',
     o: 'overwrite',
     p: 'minified-file',
     r: 'project-root',

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const DEFAULT_OPTIONS = {
   sources: {},
   endpoint: 'https://upload.bugsnag.com',
   uploadSources: false,
+  uploadNodeModules: false,
   projectRoot: '.',
   stripProjectRoot: true,
   addWildcardPrefix: false,
@@ -167,7 +168,13 @@ function transformSourcesMap(options) {
           const relativePath = stripProjectRoot(options.projectRoot, path);
           return doesFileExist(path).then(exists => {
             if (exists && options.uploadSources) {
-              options.sources[relativePath] = path;
+              if (path.indexOf("node_modules") != -1) {
+                if (options.uploadNodeModules) {
+                  options.sources[relativePath] = path;
+                }
+              } else {
+                options.sources[relativePath] = path;
+              }
             }
             return relativePath;
           });
@@ -271,6 +278,7 @@ function prepareRequest(options) {
       // Ignored settings (omit from formData)
       case 'endpoint':
       case 'uploadSources':
+      case 'uploadNodeModules':
       case 'projectRoot':
       case 'stripProjectRoot':
       case 'addWildcardPrefix':


### PR DESCRIPTION
The assumption here is that in the general case, the source contents of the files in node_modules is not as relevant to the user and can be trimmed to reduce clutter. The old behavior is still available behind a flag, however.