### PR TITLE
Validate that source map option is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ function validateOptions(options) {
   if (typeof options.apiKey !== 'string') {
     throw new Error('You must provide a valid API key to upload sourcemaps to Bugsnag.');
   }
+  if (typeof options.sourceMap !== 'string') {
+    throw new Error('You must provide a path to the source map you want to upload.')
+  }
   if (options.addWildcardPrefix && !options.stripProjectRoot) {
     options.stripProjectRoot = true;
   }

--- a/index.test.js
+++ b/index.test.js
@@ -2,6 +2,7 @@
 
 const stripProjectRoot = require('./index').stripProjectRoot
 const upload = require('./index').upload
+const validateOptions = require('./index').validateOptions
 
 test('upload function exists', () => {
   expect(typeof upload).toBe('function');
@@ -55,5 +56,18 @@ describe('stripProjectRoot', () => {
       'C:\\Users\\test\\git\\my-app',
       'C:\\Users\\test\\git\\my-app\\src\\index.js'
     )).toBe('src\\index.js');
+  });
+});
+
+describe('validateOptions', () => {
+  test('requires "apiKey"/"--api-key"', () => {
+    expect(() => {
+      validateOptions({})
+    }).toThrow('You must provide a valid API key to upload sourcemaps to Bugsnag.');
+  });
+  test('requires "sourceMap"/"--source-map"', () => {
+    expect(() => {
+      validateOptions({ apiKey: 'abbcc' })
+    }).toThrow('You must provide a path to the source map you want to upload.');
   });
 });


### PR DESCRIPTION
Addresses this issue:

> When the `sourceMap` attribute is accidentally left out of the request, the error message is not helpful: "Source map file could not be read (doesn't exist or isn't valid JSON)."