### PR TITLE
Error handling improvements

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -101,5 +101,5 @@ Promise.resolve()
     }
   })
   .then(() => {
-    return tasks.run();
+    return tasks.run().catch(err => {});
   });

--- a/index.js
+++ b/index.js
@@ -343,8 +343,10 @@ function sendRequest(args) {
  */
 function cleanupTempFiles(options) {
   return new Promise((resolve, reject) => {
-    if (options.tempDir && path.dirname(options.sourceMap) === options.tempDir) {
-      fs.unlinkSync(options.sourceMap);
+    if (options.tempDir) {
+      if (path.dirname(options.sourceMap) === options.tempDir) {
+        fs.unlinkSync(options.sourceMap);
+      }
       fs.rmdir(options.tempDir, (err) => {
         if (err) {
           reject(err);
@@ -370,8 +372,8 @@ function upload(options, callback) {
     Promise.resolve(options)
       .then(applyDefaults)
       .then(validateOptions)
-      .then(transformOptions)
       .then(opts => options = opts)
+      .then(transformOptions)
       .then(prepareRequest)
       .then(sendRequest)
       .catch(err => {

--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ function validateOptions(options) {
   if (typeof options.apiKey !== 'string') {
     throw new Error('You must provide a valid API key to upload sourcemaps to Bugsnag.');
   }
+  if (typeof options.sourceMap !== 'string') {
+    throw new Error('You must provide a path to the source map you want to upload.')
+  }
   if (options.addWildcardPrefix && !options.stripProjectRoot) {
     options.stripProjectRoot = true;
   }

--- a/index.js
+++ b/index.js
@@ -193,6 +193,12 @@ function transformSourcesMap(options) {
         return options;
       })
       .catch(err => {
+        if (err.name === 'SyntaxError') {
+          throw new Error(`Source map file was not valid JSON (${options.sourceMap})`)
+        }
+        if (err.code === 'ENOENT') {
+          throw new Error(`Source map file does not exist (${options.sourceMap})`)
+        }
         throw new Error(`Source map file could not be read (doesn't exist or isn't valid JSON).`);
       })
   );

--- a/index.test.js
+++ b/index.test.js
@@ -2,6 +2,7 @@
 
 const stripProjectRoot = require('./index').stripProjectRoot
 const upload = require('./index').upload
+const validateOptions = require('./index').validateOptions
 
 test('upload function exists', () => {
   expect(typeof upload).toBe('function');
@@ -55,5 +56,18 @@ describe('stripProjectRoot', () => {
       'C:\\Users\\test\\git\\my-app',
       'C:\\Users\\test\\git\\my-app\\src\\index.js'
     )).toBe('src\\index.js');
+  });
+});
+
+describe('validateOptions', () => {
+  test('requires "apiKey"/"--api-key"', () => {
+    expect(() => {
+      validateOptions({})
+    }).toThrow('You must provide a valid API key to upload sourcemaps to Bugsnag.');
+  });
+  test('requires "sourceMap"/"--source-map"', () => {
+    expect(() => {
+      validateOptions({ apiKey: 'abbcc' })
+    }).toThrow('You must provide a path to the source map you want to upload.');
   });
 });


### PR DESCRIPTION
This PR contains a few improvements to the way `bugsnag-sourcemaps` deals with non-happy cases. These situations are explored below:

1. CLI error duplication:

  __Before:__
  ![image](https://user-images.githubusercontent.com/609579/36319031-966a7134-1339-11e8-8007-f6c7c023e110.png)

  __After:__
  ![image](https://user-images.githubusercontent.com/609579/36319046-a5d1bec0-1339-11e8-975a-f5bc4bb77955.png)

2. Ensuring `tmpDir` gets removed when errors happen in `transformOptions`

  __Before:__
  ![image](https://user-images.githubusercontent.com/609579/36320383-f2390562-133d-11e8-8e0a-0d6a31a4930c.png)

  __After:__
  Those `bugsnag-sourcemaps*` folders do not exist.

3. More precise error messages
  __`sourceMap` option does not point to a file:__
  ![image](https://user-images.githubusercontent.com/609579/36320474-3ac40ab6-133e-11e8-8117-cd12f8794dc5.png)
  __`sourceMap` options points to a file which is not JSON:__
  ![image](https://user-images.githubusercontent.com/609579/36320495-4f3cbe0c-133e-11e8-8e58-0fb926d01249.png)