### PR TITLE
use the temporary directory specified by the OS for temporary files

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const fs = require('graceful-fs');
 const request = require('request');
 const path = require('path');
+const os = require('os');
 
 const DEFAULT_OPTIONS = {
   apiKey: null,
@@ -222,7 +223,7 @@ function transformOptions(options) {
       options.minifiedUrl = '*' + options.minifiedUrl;
   }
   if (options.stripProjectRoot) {
-    options.tempDir = fs.mkdtempSync('bugsnag-sourcemaps');
+    options.tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bugsnag-sourcemaps'));
     return transformSourcesMap(options);
   }
   return options;


### PR DESCRIPTION
### what
`fs.mkdtemp` only returns the name of the temporary folder, which means that it gets created in the current working directory. this change adds the path to the OS's temporary folder where everyone can (usually) write to.

### why
in our build process we don't have permission to write to the folder where the build is run, so using this library fails. also in theory it feels a bit better to write temporary files to an actual temporary folder.