### PR TITLE
Better handling of boolean arguments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,6 +59,12 @@ const cli = meow(`
   string: [
     'app-version',
   ],
+  boolean: [
+    'overwrite',
+    'upload-node-modules',
+    'upload-sources',
+    'add-wildcard-prefix',
+  ],
 });
 
 const conf = {

--- a/index.js
+++ b/index.js
@@ -297,6 +297,14 @@ function prepareRequest(options) {
       case 'tempDir': {
         break;
       }
+      case 'overwrite': {
+        // the presence of any value for this flag causes the API to interpret it as
+        // true, so only add it to the payload if it is truthy
+        if (options.overwrite) {
+          formData[name] = String(value);
+        }
+        break;
+      }
       // Basic fields (strings/booleans) & future fields
       default: {
         formData[name] = String(value);

--- a/index.test.js
+++ b/index.test.js
@@ -3,6 +3,7 @@
 const stripProjectRoot = require('./index').stripProjectRoot
 const upload = require('./index').upload
 const validateOptions = require('./index').validateOptions
+const prepareRequest = require('./index').prepareRequest
 
 test('upload function exists', () => {
   expect(typeof upload).toBe('function');
@@ -69,5 +70,14 @@ describe('validateOptions', () => {
     expect(() => {
       validateOptions({ apiKey: 'abbcc' })
     }).toThrow('You must provide a path to the source map you want to upload.');
+  });
+});
+
+describe('prepareRequest', () => {
+  test('removes options.overwrite when false', () => {
+    expect(prepareRequest({ overwrite: false }).formData).toEqual({});
+  });
+  test('does not remove options.overwrite when true', () => {
+    expect(prepareRequest({ overwrite: true }).formData).toEqual({ overwrite: 'true' });
   });
 });


### PR DESCRIPTION
- tells the cli argument parser which of the options are boolean flags
- ensures that the boolean `overwrite` parameter is not passed through to the API when it is `false` (this is because the body is a URL encoded form so `false` gets encoded as `"false"` which is a truthy value!)

The latter point addresses #23.