### PR TITLE
fix(cli): Don't set appVersion to empty string

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -101,7 +101,9 @@ Promise.resolve()
         readPkgUp(conf.projectRoot || process.cwd())
           .then(arg => {
             const pkg = arg && arg.pkg ? arg.pkg : null;
-            if (pkg) conf.appVersion = pkg.version;
+            // only use pkg.version if it's truthy, because read-pkg-up will
+            // set it to "" (empty string) when it's missing
+            if (pkg && pkg.version) conf.appVersion = pkg.version;
           })
       );
     }


### PR DESCRIPTION
The read-pkg-up module normalises the data in package.json, which means that if version is missing
it gets set to `""` (empty string). This causes issues with source maps not matching notifier app
versions, because a missing appVersion != `""`.