### PR TITLE
fix: Fix error handling logic for missing res param

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -21,7 +21,7 @@ const send = (url, formData, onSuccess, onError) => {
   request.post({ url, formData }, (err, res, body) => {
     if (err || res.statusCode !== 200) {
       err = err || new Error(`${res.statusMessage} (${res.statusCode}) - ${body}`)
-      if (res.statusCode < 400 || res.statusCode >= 500) {
+      if (res && (res.statusCode < 400 || res.statusCode >= 500)) {
         err.isRetryable = true
       }
       onError(err)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -77,6 +77,21 @@ test('it doesn’t retry on a 40x failure', () => {
   })
 })
 
+test('it returns the correct error in a synchronous failure', () => {
+  return upload({
+    apiKey: 'API_KEY',
+    // the easiest way to trigger a synchronous
+    // thrown error in request is a malformed url:
+    endpoint: `1231..;`,
+    sourceMap: `${__dirname}/fixtures/noop.min.js.map`
+  }).then(() => {
+    throw new Error('expected promise to be rejected')
+  }).catch(err => {
+    expect(err).toBeTruthy()
+    expect(err.message).toBe('Invalid URI "1231..;"')
+  })
+})
+
 let server, app
 const createTestServer = () => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
If a synchronous error happens, or an async error before there is an HTTP response object, the
existing logic would throw an error "Cannot read property 'statusCode' of undefined". This fix only
accesses the res property if it exists.