### PR TITLE
fix(cli): Ensure apiKey option is parsed as a string

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -58,6 +58,7 @@ const cli = meow(`
   },
   string: [
     'app-version',
+    'api-key',
   ],
   boolean: [
     'overwrite',


### PR DESCRIPTION
If the `apiKey` was entirely numbers (possible, but improbable with a 32 byte hex string) then it
would be incorrectly parsed by the arg parser as an integer and fail validation.