### PR TITLE
fix: Tolerate ENOTEMPTY when removing tmp directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,7 +343,7 @@ function cleanupTempFiles (options) {
         fs.unlinkSync(options.sourceMap)
       }
       fs.rmdir(options.tempDir, (err) => {
-        if (err) {
+        if (err && err.code !== 'ENOTEMPTY') {
           reject(err)
         } else {
           resolve()


### PR DESCRIPTION
Fixes https://github.com/bugsnag/webpack-bugsnag-plugins/issues/31.

This is a speculative fix for something that only occasionally happens on windows. For that reason, I've not reproduced or tested the issue – only checked that it still works in the happy case.