### PR TITLE
Fix --upload-sources stream/buffer logic

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -100,6 +100,8 @@ for (const key in conf) {
 }
 
 upload(conf, logger).catch(err => {
-  logger.error(`Error uploading source maps: ${err.message}`)
+  const stack = (err && err.stack) ? err.stack : err
+  const apiResponse = (err && err.errors) ? `\n\n  API response:\n    ${err.errors.join(', ')}\n` : ''
+  logger.error(`Error uploading source maps: ${stack}${apiResponse}`)
   process.exitCode = 1
 })

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function uploadMany (options, logger) {
         const minifiedUrl = path.relative(options.projectRoot, f.replace(/\.map$/, ''))
         const minifiedFile = f.replace(/\.map$/, '')
         return cb => {
-          const opts = Object.assign({}, options, { sourceMap: f, minifiedUrl: minifiedUrl, minifiedFile: minifiedFile })
+          const opts = Object.assign({}, options, { sourceMap: f, minifiedUrl: minifiedUrl, minifiedFile: minifiedFile, sources: {} })
           uploadOne(opts, logger)
             .then(() => {
               logger.info(`Upload successful (${path.basename(f)})`)

--- a/lib/options.js
+++ b/lib/options.js
@@ -103,22 +103,20 @@ function transformSourcesMap (options) {
     readFileJSON(options.sourceMap)
       .then(sourceMap => (
         mapSources(sourceMap, p => {
-          // resolve a relative path in the sources array if it begins with a ".." e.g. "../../src/index.js"
-          const resolvedPath = /^\.\./.test(p)
-            ? path.resolve(path.dirname(options.sourceMap), p)
-            : p
+          // resolve a relative path in the sources array
+          const resolvedPath = path.resolve(path.dirname(options.sourceMap), p)
 
           // then make it relative to the project root
           const relativePath = stripProjectRoot(options.projectRoot, resolvedPath)
 
-          return doesFileExist(p).then(exists => {
+          return doesFileExist(resolvedPath).then(exists => {
             if (exists && options.uploadSources) {
-              if (p.indexOf('node_modules') !== -1) {
+              if (resolvedPath.indexOf('node_modules') !== -1) {
                 if (options.uploadNodeModules) {
-                  options.sources[relativePath] = p
+                  options.sources[relativePath] = resolvedPath
                 }
               } else {
-                options.sources[relativePath] = p
+                options.sources[relativePath] = resolvedPath
               }
             }
             return relativePath

--- a/lib/prepare-request.js
+++ b/lib/prepare-request.js
@@ -73,11 +73,11 @@ module.exports = function prepareRequest (options) {
  * valid file path or whether it's a Buffer object (used for sourceMap when uploadSources
  * is set to `true`, because the sourcemap is modified).
  *
- * @param {string|Buffer} path The path of the file, or the file Buffer
+ * @param {string|Buffer} pathOrBuffer The path of the file, or the file Buffer
  * @returns {fs.ReadStream|Buffer}
  */
 function getSendableSource (pathOrBuffer) {
-  if (typeof path === 'string') {
+  if (typeof pathOrBuffer === 'string') {
     return createReadStream(pathOrBuffer)
   } else if (Buffer.isBuffer(pathOrBuffer)) {
     return pathOrBuffer

--- a/lib/request.js
+++ b/lib/request.js
@@ -51,6 +51,7 @@ const send = (endpoint, data, onSuccess, onError) => {
         return onError(err)
       } catch (_) {
         const e = new Error(`HTTP status ${res.statusCode} received from upload API`)
+        e.errors = [ body.toString() ]
         e.isRetryable = false
         return onError(e)
       }


### PR DESCRIPTION
During the refactor for #40, the wrong variable name was referenced in `getSendableSource()` which meant that the `--upload-sources` logic ceased to work, introducing #42.

While tracking this down, I also noticed that `--upload-sources` was not compatible with relative paths in the source map.

Also while tracking this down I noticed that the error information included in the API response was not surfaced to the user, so I updated the output there.

To test these fixes, using a similar setup at the OP in #42:

```
npm i -g react-native-cli
react-native init BugsnagSourceMapUploadTest
cd BugsnagSourceMapUploadTest
react-native bundle \
  --platform ios \
  --dev false \
  --entry-file index.js \
  --bundle-output ios-release.bundle \
  --sourcemap-output ios-release.bundle.map
```

Make sure you have `bugsnag-sourcemaps` cloned locally (checkout `master`) and reference it like so:

```
../../path-to/bugsnag-sourcemaps/cli.js \
  --api-key=YOUR_API_KEY \
  --app-version 1.11.111 \
  --minified-file ios-release.bundle \
  --source-map ios-release.bundle.map \
  --upload-sources
```

You should see the following error:
```
[info] Uploading (ios-release.bundle.map)
[error] Error uploading source maps: Unknown read stream path of type "string"
```

Now check out this branch (`bengourley/upload-sources-fix`) and repeat – you should see a successful upload (if you used a valid api key) or an API error (invalid API key, uploading source maps for an existing version etc.), showing that the library sent a reasonable request.

```
[info] Uploading (ios-release.bundle.map)
```

or

```
[error] Error uploading source maps: Error: HTTP status 401 received from upload API
    at res.pipe.body (/Users/bengourley/Development/bugsnag-sourcemaps/lib/request.js:40:21)
    at ConcatStream.<anonymous> (/Users/bengourley/Development/bugsnag-sourcemaps/node_modules/concat-stream/index.js:37:43)
    at ConcatStream.emit (events.js:187:15)
    at finishMaybe (/Users/bengourley/Development/bugsnag-sourcemaps/node_modules/readable-stream/lib/_stream_writable.js:620:14)
    at afterWrite (/Users/bengourley/Development/bugsnag-sourcemaps/node_modules/readable-stream/lib/_stream_writable.js:466:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

You can also use the example TypeScript project to test out the fix for `--upload-sources` in conjunction with `--directory` mode:

1. Set `"inlineSources": false` (or comment out that line) in `tsconfig.json`
1. `npm run build` – this will now build without including source content in the map
1. `npm run upload-source-maps` – this won't include sources
1. `npm start` – sends an error
1. Check that the error appears in the dashboard, but has no surrounding code
1. `npm run upload-source-maps -- --overwrite --upload-sources` re-upload source maps but tell it to include the sources
1. `npm start` – sends another error
1. Verify that the new error has surrounding code (if you are on this branch it should, but on `master` it won't)