### PR TITLE
Fix windows paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,8 +90,14 @@ function uploadMany (options, logger) {
 
       logger.info(`Found ${files.length} source map(s) to upload`)
       const uploads = files.map(f => {
-        const minifiedUrl = path.relative(options.projectRoot, f.replace(/\.map$/, ''))
+        var minifiedUrl = path.relative(options.projectRoot, f.replace(/\.map$/, ''))
         const minifiedFile = f.replace(/\.map$/, '')
+
+        // Fix paths on non-posix platforms
+        if (path.sep !== '/') {
+          minifiedUrl = minifiedUrl.split(path.sep).join('/')
+        }
+
         return cb => {
           const opts = Object.assign({}, options, { sourceMap: f, minifiedUrl: minifiedUrl, minifiedFile: minifiedFile, sources: {} })
           uploadOne(opts, logger)

--- a/lib/options.js
+++ b/lib/options.js
@@ -107,7 +107,11 @@ function transformSourcesMap (options) {
           const resolvedPath = path.resolve(path.dirname(options.sourceMap), p)
 
           // then make it relative to the project root
-          const relativePath = stripProjectRoot(options.projectRoot, resolvedPath)
+          var relativePath = stripProjectRoot(options.projectRoot, resolvedPath)
+
+          if(path.sep !== '/') {
+            relativePath = relativePath.split(path.sep).join('/')
+          }
 
           return doesFileExist(resolvedPath).then(exists => {
             if (exists && options.uploadSources) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -109,7 +109,7 @@ function transformSourcesMap (options) {
           // then make it relative to the project root
           var relativePath = stripProjectRoot(options.projectRoot, resolvedPath)
 
-          if(path.sep !== '/') {
+          if (path.sep !== '/') {
             relativePath = relativePath.split(path.sep).join('/')
           }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const concat = require('concat-stream')
+const ROOT = __dirname.split(path.sep).join('/')
 
 afterEach(() => jest.resetModules())
 
@@ -17,8 +18,8 @@ test('single uploads', () => {
   const upload = require('../').upload
   return upload({
     apiKey: 'API_KEY',
-    sourceMap: `${__dirname}/fixtures/single/noop.min.js.map`,
-    projectRoot: `${__dirname}/fixtures/single`
+    sourceMap: `${ROOT}/fixtures/single/noop.min.js.map`,
+    projectRoot: `${ROOT}/fixtures/single`
   }).then(() => {
     expect(mockCalled).toBe(1)
   })
@@ -38,7 +39,7 @@ test('multiple uploads', () => {
   const upload = require('../').upload
   return upload({
     apiKey: 'API_KEY',
-    projectRoot: `${__dirname}/fixtures/multi`,
+    projectRoot: `${ROOT}/fixtures/multi`,
     directory: true
   }).then(() => {
     expect(mockCalled).toBe(4)
@@ -54,22 +55,22 @@ test('multiple uploads', () => {
     expect(uploads).toEqual([
       {
         minifiedUrl: 'app.js',
-        minifiedFile: `${__dirname}/fixtures/multi/app.js`,
+        minifiedFile: `${ROOT}/fixtures/multi/app.js`,
         sourceMap: 'app.js.map'
       },
       {
         minifiedUrl: 'services/bugsnag.js',
-        minifiedFile: `${__dirname}/fixtures/multi/services/bugsnag.js`,
+        minifiedFile: `${ROOT}/fixtures/multi/services/bugsnag.js`,
         sourceMap: 'bugsnag.js.map'
       },
       {
         minifiedUrl: 'services/logger.js',
-        minifiedFile: `${__dirname}/fixtures/multi/services/logger.js`,
+        minifiedFile: `${ROOT}/fixtures/multi/services/logger.js`,
         sourceMap: 'logger.js.map'
       },
       {
         minifiedUrl: 'services/widget.js',
-        minifiedFile: `${__dirname}/fixtures/multi/services/widget.js`,
+        minifiedFile: `${ROOT}/fixtures/multi/services/widget.js`,
         sourceMap: 'widget.js.map'
       }
     ])
@@ -95,7 +96,7 @@ test('multiple uploads (resolving relative source paths inside map)', () => {
   const upload = require('../').upload
   return upload({
     apiKey: 'API_KEY',
-    projectRoot: `${__dirname}/fixtures/multi-relative`,
+    projectRoot: `${ROOT}/fixtures/multi-relative`,
     directory: true
   }).then(() => {
     expect(mockCalled).toBe(4)
@@ -119,22 +120,22 @@ test('multiple uploads (resolving relative source paths inside map)', () => {
     expect(uploads).toEqual([
       {
         minifiedUrl: 'lib/app.js',
-        minifiedFile: `${__dirname}/fixtures/multi-relative/lib/app.js`,
+        minifiedFile: `${ROOT}/fixtures/multi-relative/lib/app.js`,
         sourceMap: 'app.js.map'
       },
       {
         minifiedUrl: 'lib/services/bugsnag.js',
-        minifiedFile: `${__dirname}/fixtures/multi-relative/lib/services/bugsnag.js`,
+        minifiedFile: `${ROOT}/fixtures/multi-relative/lib/services/bugsnag.js`,
         sourceMap: 'bugsnag.js.map'
       },
       {
         minifiedUrl: 'lib/services/logger.js',
-        minifiedFile: `${__dirname}/fixtures/multi-relative/lib/services/logger.js`,
+        minifiedFile: `${ROOT}/fixtures/multi-relative/lib/services/logger.js`,
         sourceMap: 'logger.js.map'
       },
       {
         minifiedUrl: 'lib/services/widget.js',
-        minifiedFile: `${__dirname}/fixtures/multi-relative/lib/services/widget.js`,
+        minifiedFile: `${ROOT}/fixtures/multi-relative/lib/services/widget.js`,
         sourceMap: 'widget.js.map'
       }
     ])


### PR DESCRIPTION
I was having a problem uploading sourcemaps from a Windows system using the `--directory` flag. Paths were being uploaded with backslashes which caused bugsnag not to pick up the sourcemaps correctly.

This replaces any backslashes in `minifiedUrl` and `sources` with the corresponding posix style path. As an added benefit the tests suite is closer to passing on Windows.

Unfortunately, there is some weirdness with the sorting of the arrays that causes them to sort randomly. I've fiddled with the `sort()` calls but the best I could do was make the tests pass every other run.