### PR TITLE
test: Fix some tests

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -49,7 +49,7 @@ test('multiple uploads', () => {
         minifiedFile: payload.minifiedFile.path,
         sourceMap: path.basename(payload.sourceMap.path)
       })
-    }, []).sort((a, b) => a.minifiedUrl > b.minifiedUrl)
+    }, []).sort((a, b) => (a.minifiedUrl > b.minifiedUrl) ? 1 : -1)
 
     expect(uploads).toEqual([
       {
@@ -107,7 +107,7 @@ test('multiple uploads (resolving relative source paths inside map)', () => {
         sourceMap: path.basename(payload.sourceMap.path),
         sourceMapData: payload.sourceMapData
       })
-    }, []).sort((a, b) => a.minifiedUrl > b.minifiedUrl)
+    }, []).sort((a, b) => (a.minifiedUrl > b.minifiedUrl) ? 1 : -1)
 
     const orderedSourceMapContent = uploads.map(u => {
       const data = u.sourceMapData


### PR DESCRIPTION
After a fresh clone/install of the project `npm test` is failing on some tests, when testing equality of array fixture v.s array produced by test.

The array content is similar to the fixture one, but not ordered the same way, failing jest `expect.toEqual` call.

After looking into it, it's just due to an incorrect implementation of the `compareFunction` provided to `sort` function. This function should return either `1` (if a > b), `-1` (if a < b) or `0` (if a === b), but current implementation was returning a bool being coerced to `0` (if false) or `1` (if true), leading to the problem.

Please note that this failure wasn't noticed before because it is dependent on the version of node being used.  I was running current LTS (12.15.0) when running into this test failure, but the test failure does not appear when running Node 8 (I didn't try other versions, so not sure from which version it appears). Probably due to a different internal implementation of the `sort` function in recent node versions, dealing a bit differently with ordering of identical values.