### PR TITLE
feat: Add support for custom node http agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ import path from 'path';
 import { upload } from 'bugsnag-sourcemaps';
 
 upload({
+  agent, // optional (node http agent)
   apiKey: 'YOUR_API_KEY_HERE',
   appVersion: '1.2.3', // optional
   codeBundleId: '1.0-123', // optional (react-native only)

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const noopLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () 
  * @returns {Promise<string>}
  */
 function sendRequest (options) {
-  return new Promise((resolve, reject) => request(options.endpoint, () => prepareRequest(options), () => resolve(options), reject))
+  return new Promise((resolve, reject) => request(options.endpoint, () => prepareRequest(options), () => resolve(options), reject, options))
 }
 
 /**

--- a/lib/prepare-request.js
+++ b/lib/prepare-request.js
@@ -47,7 +47,8 @@ module.exports = function prepareRequest (options) {
       case 'projectRoot':
       case 'stripProjectRoot':
       case 'addWildcardPrefix':
-      case 'tempDir': {
+      case 'tempDir': 
+      case 'agent': {
         break
       }
       case 'overwrite': {

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,18 +11,18 @@ const MAX_ATTEMPTS = 5
 const RETRY_INTERVAL = parseInt(process.env.BUGSNAG_RETRY_INTERVAL) || 1000
 const TIMEOUT = parseInt(process.env.BUGSNAG_TIMEOUT) || 30000
 
-module.exports = (endpoint, makePayload, onSuccess, onError) => {
+module.exports = (endpoint, makePayload, onSuccess, onError, opts) => {
   let attempts = 0
   const maybeRetry = (err) => {
     attempts++
     if (err && err.isRetryable !== false && attempts < MAX_ATTEMPTS) return setTimeout(go, RETRY_INTERVAL)
     return onError(err)
   }
-  const go = () => send(endpoint, makePayload(), onSuccess, maybeRetry)
+  const go = () => send(endpoint, makePayload(), onSuccess, maybeRetry, opts)
   go()
 }
 
-const send = (endpoint, data, onSuccess, onError) => {
+const send = (endpoint, data, onSuccess, onError, opts) => {
   onError = once(onError)
   const formData = new FormData()
   Object.keys(data).forEach(k => formData.append(k, data[k]))
@@ -32,7 +32,8 @@ const send = (endpoint, data, onSuccess, onError) => {
     hostname: parsedUrl.hostname,
     path: parsedUrl.path || '/',
     headers: formData.getHeaders(),
-    port: parsedUrl.port || undefined
+    port: parsedUrl.port || undefined,
+    agent: opts && opts.agent
   }, res => {
     res.pipe(concat(body => {
       if (res.statusCode === 200) return onSuccess()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ afterEach(() => jest.resetModules())
 test('single uploads', () => {
   let mockCalled = 0
   jest.mock('../lib/request', () => {
-    return (endpoint, makePayload, onSuccess, onError) => {
+    return (endpoint, makePayload, onSuccess, onError, opts) => {
       mockCalled++
       onSuccess()
     }
@@ -28,7 +28,7 @@ test('multiple uploads', () => {
   let mockCalled = 0
   let mockCalledWith = []
   jest.mock('../lib/request', () => {
-    return (endpoint, makePayload, onSuccess, onError) => {
+    return (endpoint, makePayload, onSuccess, onError, opts) => {
       mockCalled++
       mockCalledWith.push(makePayload())
       onSuccess()
@@ -81,7 +81,7 @@ test('multiple uploads (resolving relative source paths inside map)', () => {
   let mockCalledWith = []
   const mockConcat = concat
   jest.mock('../lib/request', () => {
-    return (endpoint, makePayload, onSuccess, onError) => {
+    return (endpoint, makePayload, onSuccess, onError, opts) => {
       mockCalled++
       const payload = makePayload()
       payload.sourceMap.pipe(mockConcat(data => {
@@ -153,7 +153,7 @@ test('webpack paths', () => {
   let mockCalledWith = []
   const mockConcat = concat
   jest.mock('../lib/request', () => {
-    return (endpoint, makePayload, onSuccess, onError) => {
+    return (endpoint, makePayload, onSuccess, onError, opts) => {
       mockCalled++
       const payload = makePayload()
       payload.sourceMap.pipe(mockConcat(data => {


### PR DESCRIPTION
We have a complex enterprise CI infrastructure in which we have to go through a proxy to tunnel requests to external servers. 

One way to make http(s) requests go through a proxy in Node.js is to setup a custom [http agent](https://nodejs.org/api/http.html#http_class_http_agent) and pass it in [http.request options](https://nodejs.org/api/http.html#http_http_request_url_options_callback).

This PR updates some functions to propagate the options that were set by the client. Ultimately, the `request` call will set the `agent` in the http.request options if it is set in client provided options.

Please note that this `agent` option is only exposed through programmatic usage of the package (that's our usage of it). It is not surfaced as a new CLI option (would be complex to). That being said, as a follow up of this PR, one could update the CLI to expose a new `http-proxy` option, for user to pass a proxy url, and internally could make use of [tunnel](https://www.npmjs.com/package/tunnel) -or other lib-, to create an agent from this url and pass it to the `upload` options so that it gets set in the http request.