### PR TITLE
Code-bundle-id should be typed as a string in the meow config

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -71,7 +71,8 @@ const cli = meow(`
   },
   string: [
     'app-version',
-    'api-key'
+    'api-key',
+    'code-bundle-id'
   ],
   boolean: [
     'overwrite',


### PR DESCRIPTION
Code-bundle-id should be typed as a string in the meow config so that it isn't processed as a number.

E.g.,`--code-bundle-id=953531e1` was uploading a sourcemap with bundle id `9535310`